### PR TITLE
Bump base dependency to allow 4.15.0.0

### DIFF
--- a/cryptohash-sha1.cabal
+++ b/cryptohash-sha1.cabal
@@ -41,7 +41,7 @@ source-repository head
 
 library
   default-language:  Haskell2010
-  build-depends:     base             >= 4.5   && < 4.12
+  build-depends:     base             >= 4.5   && < 4.16
                    , bytestring       >= 0.9.2 && < 0.11
 
   hs-source-dirs:    src


### PR DESCRIPTION
Dear @hvr,

- This PR is intended to allow build `cryptohash-sha1` with GHC 9.0 (`cabal-install-3.4.0.0`, `base-4.15.0.0`).
- There is only one call `withForeignPtr` and I see nothing wrong with it.
- Locally tests were passed:
     ```
    cabal v2-test
    Build profile: -w ghc-9.0.1 -O1
    In order, the following will be built (use -v for more details):
     - cryptohash-sha1-0.11.101.0 (test:test-sha1) (ephemeral targets)
    Preprocessing test suite 'test-sha1' for cryptohash-sha1-0.11.101.0..
    Building test suite 'test-sha1' for cryptohash-sha1-0.11.101.0..
    Running 1 test suites...
    Test suite test-sha1: RUNNING...
    Test suite test-sha1: PASS
    Test suite logged to:
    $HOME/cryptohash-sha1/dist-newstyle/build/x86_64-osx/ghc-9.0.1/cryptohash-sha1-0.11.101.0/t/test-sha1/test/cryptohash-sha1-0.11.101.0-test-sha1.log
    1 of 1 test suites (1 of 1 test cases) passed.
    ```

Closes #10.

Kind regards,
@swamp-agr